### PR TITLE
Added pre_install_hook for roles pulled in via galaxy

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -157,6 +157,18 @@
   tasks:
 
     - block:
+        - name: detect pre_install_hook.(yml/yaml)
+          stat: path={{item}}
+          register: doesPreInstallHookExist
+          with_fileglob:
+            - "{{project_path|quote}}/roles/pre_install_hook.yml"
+            - "{{project_path|quote}}/roles/pre_install_hook.yaml"
+            
+        - name: include roles/pre_install_hook.(yml/yaml)
+          include: "{{ item.item }}"
+          with_items: "{{ doesPreInstallHookExist.results }}"
+          when: item.stat.exists
+          
         - name: fetch galaxy roles from requirements.(yml/yaml)
           command: >
             ansible-galaxy role install -r {{ item }}


### PR DESCRIPTION


##### SUMMARY
Include an optional roles/pre_install_hook.(yml/yaml) before the actual galaxy install command is run.
This allows for example a dynamic requirements.yml/yaml file which is then fed to galaxy.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Core (updating projects)

##### AWX VERSION
```
19.1.0
```



